### PR TITLE
Fix block_timestamp epoch to Jan 1, 2025

### DIFF
--- a/src/wirejs-serialize.ts
+++ b/src/wirejs-serialize.ts
@@ -742,12 +742,12 @@ export const timePointSecToDate = (sec: number): string => {
 
 /** Convert date in ISO format to `block_timestamp_type` (half-seconds since a different epoch) */
 export const dateToBlockTimestamp = (date: string): number => {
-  return Math.round((checkDateParse(date + "Z") - 946684800000) / 500);
+  return Math.round((checkDateParse(date + "Z") - 1735689600000) / 500);
 };
 
 /** Convert `block_timestamp_type` (half-seconds since a different epoch) to to date in ISO format */
 export const blockTimestampToDate = (slot: number): string => {
-  const s = new Date(slot * 500 + 946684800000).toISOString();
+  const s = new Date(slot * 500 + 1735689600000).toISOString();
   return s.substr(0, s.length - 1);
 };
 


### PR DESCRIPTION
## Summary
- Update `dateToBlockTimestamp` and `blockTimestampToDate` epoch from `946684800000` (Jan 1, 2000) to `1735689600000` (Jan 1, 2025)
- Aligns with wire-sysio commit b2d8793f27 which changed `block_timestamp_epoch`

## Context
Hyperion was producing incorrect timestamps (off by 25 years) because the JS serialization layer still used the old EOSIO Y2K epoch.