### PR TITLE
Add enum type support to wirejs serializer

### DIFF
--- a/src/wirejs-rpc-interfaces.ts
+++ b/src/wirejs-rpc-interfaces.ts
@@ -30,6 +30,7 @@ export interface Abi {
   error_messages: { error_code: number; error_msg: string }[];
   abi_extensions: { tag: number; value: string }[];
   variants?: { name: string; types: string[] }[];
+  enums?: { name: string; type: string; values: { name: string; value: number }[] }[];
   action_results?: { name: string; result_type: string }[];
   kv_tables?: {
     [key: string]: {

--- a/src/wirejs-serialize.ts
+++ b/src/wirejs-serialize.ts
@@ -1934,6 +1934,40 @@ export const getTypesFromAbi = (
     }
   }
 
+  if (abi && abi.enums) {
+    for (const { name, type: underlyingTypeName, values } of abi.enums) {
+      const underlyingType = getType(types, underlyingTypeName);
+      types.set(
+        name,
+        createType({
+          name,
+          serialize: (buffer: SerialBuffer, data: string | number) => {
+            let numVal: number;
+            if (typeof data === "string") {
+              const entry = values.find((v) => v.name === data);
+              if (entry !== undefined) {
+                numVal = entry.value;
+              } else {
+                numVal = +data;
+                if (Number.isNaN(numVal)) {
+                  throw new Error(`Unknown enum value: ${data}`);
+                }
+              }
+            } else {
+              numVal = data;
+            }
+            underlyingType.serialize(buffer, numVal);
+          },
+          deserialize: (buffer: SerialBuffer) => {
+            const numVal = underlyingType.deserialize(buffer);
+            const entry = values.find((v) => v.value === +numVal);
+            return entry ? entry.name : String(numVal);
+          },
+        }),
+      );
+    }
+  }
+
   for (const [name, type] of types) {
     if (type.baseName) {
       type.base = getType(types, type.baseName);


### PR DESCRIPTION
## Summary
- Add `enums` field to the `Abi` interface in `wirejs-rpc-interfaces.ts`
- Add enum processing to `getTypesFromAbi()` in `wirejs-serialize.ts` — registers each ABI enum as a serializable type using its underlying integer type with symbolic name lookup

Fixes "Unknown type: trx_match_type" errors when Hyperion's wirejs fallback path deserializes actions containing enum fields.