### PR TITLE
Update abi_def schema for wire-sysio table_id namespace isolation

### DIFF
--- a/src/wirejs-jsonrpc.ts
+++ b/src/wirejs-jsonrpc.ts
@@ -296,61 +296,42 @@ export class JsonRpc implements AuthorityProvider, AbiProvider {
     });
   }
 
-  /** Raw call to `/v1/chain/get_table_rows` */
+  /**
+   * Raw call to `/v1/chain/get_table_rows`.
+   *
+   * Wire-sysio PR #290 unified the legacy `get_table_rows` and `get_kv_table_rows`
+   * endpoints into a single API. `scope` is optional (empty = unscoped); `find`
+   * performs an exact-key lookup (cannot combine with bounds); `index_name` selects
+   * a secondary index by name or numeric position. Legacy `index_position` and
+   * `key_type` are removed — the ABI drives type resolution now.
+   */
   public async get_table_rows({
     json = true,
     code,
-    scope,
     table,
+    scope = "",
+    find = "",
+    index_name = "",
     lower_bound = "",
     upper_bound = "",
-    index_position = 1,
-    key_type = "",
-    limit = 10,
+    limit = 50,
     reverse = false,
     show_payer = false,
+    time_limit_ms,
   }: any): Promise<GetTableRowsResult> {
     return await this.fetch("/v1/chain/get_table_rows", {
       json,
       code,
+      table,
       scope,
-      table,
-      lower_bound,
-      upper_bound,
-      index_position,
-      key_type,
-      limit,
-      reverse,
-      show_payer,
-    });
-  }
-
-  /** Raw call to `/v1/chain/get_kv_table_rows` */
-  public async get_kv_table_rows({
-    json = true,
-    code,
-    table,
-    index_name,
-    encode_type = "bytes",
-    index_value,
-    lower_bound,
-    upper_bound,
-    limit = 10,
-    reverse = false,
-    show_payer = false,
-  }: any): Promise<GetTableRowsResult> {
-    return await this.fetch("/v1/chain/get_kv_table_rows", {
-      json,
-      code,
-      table,
+      find,
       index_name,
-      encode_type,
-      index_value,
       lower_bound,
       upper_bound,
       limit,
       reverse,
       show_payer,
+      time_limit_ms,
     });
   }
 

--- a/src/wirejs-rpc-interfaces.ts
+++ b/src/wirejs-rpc-interfaces.ts
@@ -25,9 +25,16 @@ export interface Abi {
     index_type: string;
     key_names: string[];
     key_types: string[];
-    /** DJB2(name) % 65536; namespace slot for KV tables (wire-sysio PR #288). */
+    /**
+     * DJB2(name) % 65536; namespace slot for KV tables (wire-sysio PR #288).
+     * Optional on this interface for forward-compat with JSON payloads from older
+     * nodes, but REQUIRED by the binary serializer: callers constructing a
+     * `table_def` for `createAbiTypes()` round-trip against a wire-sysio post-#288
+     * node MUST provide `table_id` and `secondary_indexes` or binary encoding will
+     * fail / produce a malformed ABI.
+     */
     table_id?: number;
-    /** Per-secondary-index metadata; each entry has its own table_id. */
+    /** Per-secondary-index metadata; each entry has its own table_id. Required for binary round-trip; see `table_id`. */
     secondary_indexes?: { name: string; key_type: string; table_id: number }[];
   }[];
   ricardian_clauses: { id: string; body: string }[];
@@ -495,12 +502,17 @@ export interface GetScheduledTransactionsResult {
   more: string;
 }
 
-/** Return value of `/v1/chain/get_table_rows` and `/v1/chain/get_kv_table_rows` */
+/**
+ * Return value of `/v1/chain/get_table_rows`.
+ *
+ * Wire-sysio PR #290 unified the legacy `get_table_rows` and `get_kv_table_rows`
+ * endpoints; `next_key_bytes` (legacy hex pagination token) was dropped — use
+ * `next_key` as the pagination token for both legacy and KV tables.
+ */
 export interface GetTableRowsResult {
   rows: any[];
   more: boolean;
   next_key: string;
-  next_key_bytes: string;
 }
 
 export interface GetTableByScopeResultRow {

--- a/src/wirejs-rpc-interfaces.ts
+++ b/src/wirejs-rpc-interfaces.ts
@@ -25,6 +25,10 @@ export interface Abi {
     index_type: string;
     key_names: string[];
     key_types: string[];
+    /** DJB2(name) % 65536; namespace slot for KV tables (wire-sysio PR #288). */
+    table_id?: number;
+    /** Per-secondary-index metadata; each entry has its own table_id. */
+    secondary_indexes?: { name: string; key_type: string; table_id: number }[];
   }[];
   ricardian_clauses: { id: string; body: string }[];
   error_messages: { error_code: number; error_msg: string }[];
@@ -32,13 +36,8 @@ export interface Abi {
   variants?: { name: string; types: string[] }[];
   enums?: { name: string; type: string; values: { name: string; value: number }[] }[];
   action_results?: { name: string; result_type: string }[];
-  kv_tables?: {
-    [key: string]: {
-      type: string;
-      primary_index: { name: string; type: string };
-      secondary_indices: { [key: string]: { type: string } }[];
-    };
-  }[];
+  /** Protobuf FileDescriptorSet serialized as a JSON string (may_not_exist on chain side). */
+  protobuf_types?: string;
 }
 
 export interface BlockHeader {

--- a/src/wirejs-rpc-interfaces.ts
+++ b/src/wirejs-rpc-interfaces.ts
@@ -34,6 +34,12 @@ export interface Abi {
   error_messages: { error_code: number; error_msg: string }[];
   abi_extensions: { tag: number; value: string }[];
   variants?: { name: string; types: string[] }[];
+  /**
+   * Enum value is `int64_t` on the chain side but typed here as `number`. TypeScript `number`
+   * is a 64-bit float with exact integer range [-2^53, 2^53]; values beyond that would silently
+   * lose precision. Safe for all expected enum values, which are small integers by convention.
+   * Switch to `bigint` if larger enum values ever become necessary.
+   */
   enums?: { name: string; type: string; values: { name: string; value: number }[] }[];
   action_results?: { name: string; result_type: string }[];
   /** Protobuf FileDescriptorSet serialized as a JSON string (may_not_exist on chain side). */

--- a/src/wirejs-serialize.ts
+++ b/src/wirejs-serialize.ts
@@ -1569,17 +1569,42 @@ export const createAbiTypes = (): Map<string, Type> => {
       deserialize: deserializeStruct,
     }),
   );
+  // Per-secondary-index metadata embedded in table_def. Mirrors
+  // sysio::chain::index_def in wire-sysio's
+  // libraries/chain/include/sysio/chain/abi_def.hpp.
+  initialTypes.set(
+    "index_def",
+    createType({
+      name: "index_def",
+      baseName: "",
+      fields: [
+        { name: "name", typeName: "string", type: null },
+        { name: "key_type", typeName: "string", type: null },
+        { name: "table_id", typeName: "uint16", type: null },
+      ],
+      serialize: serializeStruct,
+      deserialize: deserializeStruct,
+    }),
+  );
+  // Wire-sysio PR Wire-Network/wire-sysio#288 widened table_def.name from
+  // sysio::name (uint64) to free-form std::string so long table names work,
+  // and added table_id (uint16, DJB2 hash of the table name % 65536) and
+  // secondary_indexes for KV table indexing. The binary wire format break
+  // means this struct must mirror the chain side exactly or every field
+  // after `tables` in abi_def parses misaligned.
   initialTypes.set(
     "table_def",
     createType({
       name: "table_def",
       baseName: "",
       fields: [
-        { name: "name", typeName: "name", type: null },
+        { name: "name", typeName: "string", type: null },
         { name: "index_type", typeName: "string", type: null },
         { name: "key_names", typeName: "string[]", type: null },
         { name: "key_types", typeName: "string[]", type: null },
         { name: "type", typeName: "string", type: null },
+        { name: "table_id", typeName: "uint16", type: null },
+        { name: "secondary_indexes", typeName: "index_def[]", type: null },
       ],
       serialize: serializeStruct,
       deserialize: deserializeStruct,
@@ -1716,6 +1741,43 @@ export const createAbiTypes = (): Map<string, Type> => {
       deserialize: deserializeObject,
     }),
   );
+  // Enum type definitions matching wire-sysio's sysio::chain::enum_def /
+  // enum_value_def in libraries/chain/include/sysio/chain/abi_def.hpp.
+  // Required for binary deserialization of contract ABIs that use enum
+  // fields and for the enum support added in PR #3.
+  initialTypes.set(
+    "enum_value_def",
+    createType({
+      name: "enum_value_def",
+      baseName: "",
+      fields: [
+        { name: "name", typeName: "string", type: null },
+        { name: "value", typeName: "int64", type: null },
+      ],
+      serialize: serializeStruct,
+      deserialize: deserializeStruct,
+    }),
+  );
+  initialTypes.set(
+    "enum_def",
+    createType({
+      name: "enum_def",
+      baseName: "",
+      fields: [
+        { name: "name", typeName: "string", type: null },
+        { name: "type", typeName: "string", type: null },
+        { name: "values", typeName: "enum_value_def[]", type: null },
+      ],
+      serialize: serializeStruct,
+      deserialize: deserializeStruct,
+    }),
+  );
+  // abi_def matches wire-sysio's sysio::chain::abi_def reflection layout in
+  // libraries/chain/include/sysio/chain/abi_def.hpp:
+  //   variants$, action_results$, enums$, protobuf_types$
+  // The legacy `kv_tables$` extension was for EOSIO's old kv_table proposal —
+  // unrelated to wire-sysio's kv::table — and is removed because the wire
+  // stream now contains `enums` then `protobuf_types` at that position.
   initialTypes.set(
     "abi_def",
     createType({
@@ -1732,7 +1794,8 @@ export const createAbiTypes = (): Map<string, Type> => {
         { name: "abi_extensions", typeName: "extensions_entry[]", type: null },
         { name: "variants", typeName: "variant_def[]$", type: null },
         { name: "action_results", typeName: "action_result[]$", type: null },
-        { name: "kv_tables", typeName: "kv_table$", type: null },
+        { name: "enums", typeName: "enum_def[]$", type: null },
+        { name: "protobuf_types", typeName: "string$", type: null },
       ],
       serialize: serializeStruct,
       deserialize: deserializeStruct,

--- a/src/wirejs-serialize.ts
+++ b/src/wirejs-serialize.ts
@@ -1570,8 +1570,14 @@ export const createAbiTypes = (): Map<string, Type> => {
     }),
   );
   // Per-secondary-index metadata embedded in table_def. Mirrors
-  // sysio::chain::index_def in wire-sysio's
-  // libraries/chain/include/sysio/chain/abi_def.hpp.
+  // sysio::chain::index_def in libraries/chain/include/sysio/chain/abi_def.hpp:
+  //   struct index_def { string name; string key_type; uint16_t table_id = 0; };
+  //   FC_REFLECT( sysio::chain::index_def, (name)(key_type)(table_id) )
+  // Field order and types below must match that reflection exactly.
+  //
+  // Note: this `table_id` is the hash identifier for THIS secondary index,
+  // not the parent table's table_id. Each secondary index gets its own
+  // DJB2(index_name) % 65536 slot so chain-side lookups can address it.
   initialTypes.set(
     "index_def",
     createType({
@@ -1586,12 +1592,17 @@ export const createAbiTypes = (): Map<string, Type> => {
       deserialize: deserializeStruct,
     }),
   );
-  // Wire-sysio PR Wire-Network/wire-sysio#288 widened table_def.name from
-  // sysio::name (uint64) to free-form std::string so long table names work,
-  // and added table_id (uint16, DJB2 hash of the table name % 65536) and
-  // secondary_indexes for KV table indexing. The binary wire format break
-  // means this struct must mirror the chain side exactly or every field
-  // after `tables` in abi_def parses misaligned.
+  // table_def mirrors sysio::chain::table_def in
+  // libraries/chain/include/sysio/chain/abi_def.hpp:
+  //   FC_REFLECT( sysio::chain::table_def,
+  //               (name)(index_type)(key_names)(key_types)(type)(table_id)(secondary_indexes) )
+  // Wire-sysio PR #288 widened `name` from sysio::name (uint64) to a free-form
+  // std::string so long table names work, and appended `table_id` (uint16,
+  // DJB2 hash of the table name % 65536) and `secondary_indexes`. All prior
+  // fields (index_type, key_names, key_types, type) are retained in the same
+  // order. The binary wire format break means this struct must mirror the
+  // chain side exactly or every field after `tables` in abi_def parses
+  // misaligned.
   initialTypes.set(
     "table_def",
     createType({
@@ -1662,87 +1673,13 @@ export const createAbiTypes = (): Map<string, Type> => {
       deserialize: deserializeStruct,
     }),
   );
-  initialTypes.set(
-    "primary_key_index_def",
-    createType({
-      name: "primary_key_index_def",
-      baseName: "",
-      fields: [
-        { name: "name", typeName: "name", type: null },
-        { name: "type", typeName: "string", type: null },
-      ],
-      serialize: serializeStruct,
-      deserialize: deserializeStruct,
-    }),
-  );
-  initialTypes.set(
-    "secondary_index_def",
-    createType({
-      name: "secondary_index_def",
-      baseName: "",
-      fields: [{ name: "type", typeName: "string", type: null }],
-      serialize: serializeStruct,
-      deserialize: deserializeStruct,
-    }),
-  );
-  initialTypes.set(
-    "secondary_indices",
-    createType({
-      name: "secondary_indices",
-      baseName: "",
-      fields: [
-        { name: "name", typeName: "name", type: null },
-        {
-          name: "secondary_index_def",
-          typeName: "secondary_index_def",
-          type: null,
-        },
-      ],
-      serialize: serializeObject,
-      deserialize: deserializeObject,
-    }),
-  );
-  initialTypes.set(
-    "kv_table_entry_def",
-    createType({
-      name: "kv_table_entry_def",
-      baseName: "",
-      fields: [
-        { name: "type", typeName: "string", type: null },
-        {
-          name: "primary_index",
-          typeName: "primary_key_index_def",
-          type: null,
-        },
-        {
-          name: "secondary_indices",
-          typeName: "secondary_indices",
-          type: null,
-        },
-      ],
-      serialize: serializeStruct,
-      deserialize: deserializeStruct,
-    }),
-  );
-  initialTypes.set(
-    "kv_table",
-    createType({
-      name: "kv_table",
-      baseName: "",
-      fields: [
-        { name: "name", typeName: "name", type: null },
-        {
-          name: "kv_table_entry_def",
-          typeName: "kv_table_entry_def",
-          type: null,
-        },
-      ],
-      serialize: serializeObject,
-      deserialize: deserializeObject,
-    }),
-  );
   // Enum type definitions matching wire-sysio's sysio::chain::enum_def /
-  // enum_value_def in libraries/chain/include/sysio/chain/abi_def.hpp.
+  // enum_value_def in libraries/chain/include/sysio/chain/abi_def.hpp:
+  //   struct enum_value_def { string name; int64_t value; };
+  //   struct enum_def { type_name name; type_name type; vector<enum_value_def> values; };
+  //   FC_REFLECT( sysio::chain::enum_value_def, (name)(value) )
+  //   FC_REFLECT( sysio::chain::enum_def, (name)(type)(values) )
+  // `value` is int64_t on the chain side.
   // Required for binary deserialization of contract ABIs that use enum
   // fields and for the enum support added in PR #3.
   initialTypes.set(
@@ -1772,9 +1709,17 @@ export const createAbiTypes = (): Map<string, Type> => {
       deserialize: deserializeStruct,
     }),
   );
-  // abi_def matches wire-sysio's sysio::chain::abi_def reflection layout in
-  // libraries/chain/include/sysio/chain/abi_def.hpp:
-  //   variants$, action_results$, enums$, protobuf_types$
+  // abi_def matches sysio::chain::abi_def in libraries/chain/include/sysio/chain/abi_def.hpp:
+  //   FC_REFLECT( sysio::chain::abi_def,
+  //               (version)(types)(structs)(actions)(tables)
+  //               (ricardian_clauses)(error_messages)(abi_extensions)
+  //               (variants)(action_results)(enums)(protobuf_types) )
+  // The last four (variants, action_results, enums, protobuf_types) use
+  // may_not_exist<T> on the chain side, i.e. binary extensions — hence the
+  // `$` suffix here. `protobuf_types` is a bare may_not_exist<string>
+  // (FileDescriptorSet serialized as a JSON string), which is why `string$`
+  // is the correct wire typeName, not a vector.
+  //
   // The legacy `kv_tables$` extension was for EOSIO's old kv_table proposal —
   // unrelated to wire-sysio's kv::table — and is removed because the wire
   // stream now contains `enums` then `protobuf_types` at that position.


### PR DESCRIPTION
## Summary

Wire-sysio PR Wire-Network/wire-sysio#288 changed the binary on-wire shape of `table_def`: `name` was widened from `sysio::name` (uint64) to a free-form `std::string` so long table names work, and two new fields were appended — `table_id` (uint16, DJB2 hash of the table name % 65536) and `secondary_indexes` (`vector<index_def>`) — for KV-table per-table namespace isolation. The wire format break means any wirejs-native consumer parsing a new wire-sysio ABI either fails outright or mis-parses every field after the table name.

**Companion PRs:**
- Wire-Network/wire-sysio#288 — table_id namespace isolation
- Wire-Network/wire-sysio#290 — unified `get_table_rows` API
- Wire-Network/wire-sysio#291 — sysio.token migrated to `kv::scoped_table`
- Wire-Network/abieos#__ — abieos C++ side counterpart to this change

## Changes

### `table_def` updates (line 1572 area)
- `name`: `name` → `string` (binary format break — required)
- `+table_id: uint16`
- `+secondary_indexes: index_def[]`
- New `index_def` type: `{name: string, key_type: string, table_id: uint16}`

### `abi_def` reordered to match wire-sysio
The wire-sysio reflection layout in `libraries/chain/include/sysio/chain/abi_def.hpp` is:
```
... abi_extensions, variants$, action_results$, enums$, protobuf_types$
```

This commit makes `abi_def` mirror that exactly:
- `variants$`
- `action_results$`
- **`enums$`** ← was missing
- **`protobuf_types$`** ← was missing
- **Removed legacy `kv_tables$`** — that field belonged to EOSIO's old kv_table proposal and is unrelated to wire-sysio's `kv::table`. The wire stream now contains `enums` then `protobuf_types` at that position, so consuming `kv_tables` there mis-parses every wire-sysio ABI.

### New types
- `enum_def`, `enum_value_def` so the new `enum_def[]$` field can deserialize. The runtime enum support added in #3 already processes `abi.enums` via `getTypesFromAbi()`; this commit completes the binary side of the schema.

## Out of scope

The legacy `primary_key_index_def`, `secondary_index_def`, `secondary_indices`, `kv_table_entry_def`, and `kv_table` types defined earlier in `createAbiTypes()` are now unreferenced. Left in place to avoid scope creep — can be cleaned up in a follow-on.